### PR TITLE
API Bodyのdata classの変数がキャメルケースでも認識されるようにする

### DIFF
--- a/app/src/main/java/dev/dai/githubclient/infra/api/di/ApiModule.kt
+++ b/app/src/main/java/dev/dai/githubclient/infra/api/di/ApiModule.kt
@@ -1,5 +1,8 @@
 package dev.dai.githubclient.infra.api.di
 
+import com.google.gson.FieldNamingPolicy
+import com.google.gson.Gson
+import com.google.gson.GsonBuilder
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -22,7 +25,7 @@ object ApiModule {
   fun provideGithubApi(): GithubApi {
     return Retrofit.Builder()
       .baseUrl(BASE_URL)
-      .addConverterFactory(GsonConverterFactory.create())
+      .addConverterFactory(GsonConverterFactory.create(provideGson()))
       .client(provideOkhttpClient())
       .build()
       .create(GithubApi::class.java)
@@ -33,6 +36,12 @@ object ApiModule {
       .addInterceptor(provideLogging())
       .addInterceptor(AuthorizationInterceptor())
       .build()
+  }
+
+  private fun provideGson(): Gson {
+    return GsonBuilder()
+      .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
+      .create()
   }
 
   private fun provideLogging() = HttpLoggingInterceptor().apply {

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,5 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+# Custom properties
+GITHUB_TOKEN="\"REPLACE_YOUR_GITHUB_TOKEN\""


### PR DESCRIPTION
# 概要
- Gsonはキャメルケースの変数を自動でスネークケースとして認識してくれないので、namingPolicyを追加する
- Github TOKENをgradle.propertiesに置くように定義だけgitに上げる

# 対応issue
なし