### PR TITLE
ユーザー検索画面のOneShotEventハンドリング処理を追加する

### DIFF
--- a/app/src/main/java/dev/dai/githubclient/ui/component/LoadingContent.kt
+++ b/app/src/main/java/dev/dai/githubclient/ui/component/LoadingContent.kt
@@ -1,0 +1,23 @@
+package dev.dai.githubclient.ui.component
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+
+@Composable
+fun LoadingContent() {
+  Surface(
+    color = Color.Transparent,
+    modifier = Modifier.fillMaxSize()
+  ) {
+    Box(contentAlignment = Alignment.Center) {
+      CircularProgressIndicator(color = MaterialTheme.colors.secondary)
+    }
+  }
+}

--- a/app/src/main/java/dev/dai/githubclient/ui/user_search/UserSearchScreen.kt
+++ b/app/src/main/java/dev/dai/githubclient/ui/user_search/UserSearchScreen.kt
@@ -38,6 +38,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import coil.compose.AsyncImage
 import dev.dai.githubclient.R
 import dev.dai.githubclient.domain.model.UserSearchResult
+import dev.dai.githubclient.ui.component.LoadingContent
 import dev.dai.githubclient.ui.theme.GithubClientTheme
 
 @Composable
@@ -80,7 +81,9 @@ fun UserSearchScreen(
     }
   }
 
-  // TODO Loading handling
+  if (uiState.isLoading) {
+    LoadingContent()
+  }
 }
 
 @Composable

--- a/app/src/main/java/dev/dai/githubclient/ui/user_search/UserSearchScreen.kt
+++ b/app/src/main/java/dev/dai/githubclient/ui/user_search/UserSearchScreen.kt
@@ -19,9 +19,12 @@ import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.OutlinedTextField
 import androidx.compose.material.Scaffold
+import androidx.compose.material.ScaffoldState
 import androidx.compose.material.Text
 import androidx.compose.material.TopAppBar
+import androidx.compose.material.rememberScaffoldState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -38,11 +41,13 @@ import dev.dai.githubclient.ui.theme.GithubClientTheme
 
 @Composable
 fun UserSearchScreen(
-  viewModel: UserSearchViewModel = viewModel()
+  viewModel: UserSearchViewModel = viewModel(),
+  scaffoldState: ScaffoldState = rememberScaffoldState()
 ) {
   val uiState = viewModel.uiState
 
   Scaffold(
+    scaffoldState = scaffoldState,
     modifier = Modifier.fillMaxSize(),
     topBar = {
       TopAppBar(
@@ -61,7 +66,19 @@ fun UserSearchScreen(
     )
   }
 
-  // TODO Event handling
+  uiState.event?.let {
+    when (it) {
+      UserSearchEvent.FetchError -> {
+        val message = stringResource(id = R.string.message_failed_fetch)
+        LaunchedEffect(scaffoldState.snackbarHostState) {
+          scaffoldState.snackbarHostState.showSnackbar(message)
+          // LaunchedEffect外で呼ぶと先にconsumeされてしまいsnackBarが表示されないので、ここでconsumeする
+          viewModel.consumeEvent()
+        }
+      }
+    }
+  }
+
   // TODO Loading handling
 }
 

--- a/app/src/main/java/dev/dai/githubclient/ui/user_search/UserSearchScreen.kt
+++ b/app/src/main/java/dev/dai/githubclient/ui/user_search/UserSearchScreen.kt
@@ -2,6 +2,7 @@ package dev.dai.githubclient.ui.user_search
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -96,13 +97,25 @@ private fun UserSearchScreenContent(
       onSearchTextChanged = onSearchTextChanged,
       onClickSearch = onClickSearch
     )
-    LazyColumn {
-      items(userList) {
-        UserItem(
-          userName = it.userName,
-          imageUrl = it.avatarUrl,
-          onClickRow = onClickUserRow
+    if (userList.isEmpty()) {
+      Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+      ) {
+        Text(
+          text = stringResource(id = R.string.message_empty_user_search_result),
+          style = MaterialTheme.typography.subtitle1
         )
+      }
+    } else {
+      LazyColumn {
+        items(userList) {
+          UserItem(
+            userName = it.userName,
+            imageUrl = it.avatarUrl,
+            onClickRow = onClickUserRow
+          )
+        }
       }
     }
   }

--- a/app/src/main/java/dev/dai/githubclient/ui/user_search/UserSearchViewModel.kt
+++ b/app/src/main/java/dev/dai/githubclient/ui/user_search/UserSearchViewModel.kt
@@ -28,11 +28,7 @@ class UserSearchViewModel @Inject constructor(
     viewModelScope.launch {
       try {
         val result = searchRepository.searchUser(uiState.searchText)
-        uiState = if (result.totalCount == 0) {
-          uiState.copy(event = UserSearchEvent.UserNotFound)
-        } else {
-          uiState.copy(userList = result.userList)
-        }
+        uiState = uiState.copy(userList = result.userList)
       } catch (e: Exception) {
         uiState = uiState.copy(event = UserSearchEvent.FetchError)
       } finally {
@@ -55,5 +51,4 @@ data class UserSearchUiState(
 
 sealed interface UserSearchEvent {
   object FetchError : UserSearchEvent
-  object UserNotFound : UserSearchEvent
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,4 +3,6 @@
     <string name="title_user_search">ユーザー検索</string>
     <string name="label_search">検索</string>
     <string name="label_user_name">ユーザー名</string>
+    <string name="message_failed_fetch">通信に失敗しました。再度お試しください。</string>
+    <string name="message_empty_user_search_result">検索結果なし</string>
 </resources>


### PR DESCRIPTION
# 概要
- 通信エラー時はSnackbarでエラー文言を表示する
  - 今回はHTTPステータスごとのエラー判別は行わず、一律でエラー文言を表示する
- 検索結果が0件の場合は画面中央にメッセージを表示する
- ローディング中はProgressBarを表示する

# 対応issue
- #4 