### PR TITLE
UIの細かい修正

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,7 +18,8 @@
         <activity
             android:name=".ui.user_search.UserSearchActivity"
             android:exported="true"
-            android:theme="@style/Theme.GithubClient">
+            android:theme="@style/Theme.GithubClient"
+            android:windowSoftInputMode="adjustResize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/dev/dai/githubclient/ui/user_search/UserSearchScreen.kt
+++ b/app/src/main/java/dev/dai/githubclient/ui/user_search/UserSearchScreen.kt
@@ -1,6 +1,8 @@
 package dev.dai.githubclient.ui.user_search
 
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -143,7 +145,11 @@ private fun UserSearchHeader(
       label = { Text(text = stringResource(id = R.string.label_user_name)) },
       singleLine = true,
       trailingIcon = {
-        AnimatedVisibility(visible = searchText.isNotEmpty()) {
+        AnimatedVisibility(
+          visible = searchText.isNotEmpty(),
+          enter = fadeIn(),
+          exit = fadeOut()
+        ) {
           IconButton(onClick = { onSearchTextChanged("") }) {
             Icon(painter = painterResource(id = R.drawable.ic_cancel), contentDescription = null)
           }

--- a/app/src/main/java/dev/dai/githubclient/ui/user_search/UserSearchScreen.kt
+++ b/app/src/main/java/dev/dai/githubclient/ui/user_search/UserSearchScreen.kt
@@ -139,7 +139,9 @@ private fun UserSearchHeader(
     OutlinedTextField(
       value = searchText,
       onValueChange = onSearchTextChanged,
+      modifier = Modifier.weight(1f),
       label = { Text(text = stringResource(id = R.string.label_user_name)) },
+      singleLine = true,
       trailingIcon = {
         AnimatedVisibility(visible = searchText.isNotEmpty()) {
           IconButton(onClick = { onSearchTextChanged("") }) {


### PR DESCRIPTION
# 概要
- TextFieldのCancelアイコンのアニメーションをfadeInとfadeOutだけ行うように修正
- IMEで隠れたitem部分をスクロールして確認できるように、AndroidManifestにadjustResizeを設定
- TextFieldの入力で改行させないように修正