### PR TITLE
GITHUB_TOKENをlocal.propertiesで管理するように修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # ComposeGithubClient
+
 Github Client for Android Jetpack Compose
 
 ## Development
+
 ### Feature
+
 - Search user by Github username.
 - Show user information and user's repository list
 
@@ -11,38 +14,52 @@ Github Client for Android Jetpack Compose
 |<img src="https://user-images.githubusercontent.com/19250035/179735564-ae24f0f5-eb9c-4168-ba12-8042c59b7f85.png" width=300>||
 
 ### Getting Started
+
 Required latest Android Studio.
 
 This project build to need Github personal access token.
-You can create it from [this page](https://github.com/settings/tokens) and select scopes **repo** and **user**.
+You can create it from [this page](https://github.com/settings/tokens) and select scopes **repo**
+and **user**.
+And write token in local.properties.
+
+```properties
+GITHUB_TOKEN={YOUR_GITHUB_TOKEN}
+```
 
 ### Design
+
 [Figma](https://www.figma.com/file/5YY2fYOYhYO1SNfld1mVgC/Github-Client?node-id=1037%3A3346)
 
 ## Architecture
+
 2Layer Architecture.
+
 - UI layer
-  - Activity
-  - Jetpack Compose
-    - Screen Composable
-    - Content Composable
-    - Component Composables
-  - ViewModel
+    - Activity
+    - Jetpack Compose
+        - Screen Composable
+        - Content Composable
+        - Component Composables
+    - ViewModel
 - Data Layer
-  - Repository
-  - ApiClient
+    - Repository
+    - ApiClient
 
 FYI: https://developer.android.com/topic/architecture#recommended-app-arch
 
 ## Tech Stacks
+
 ### UI
+
 - Multi Activity + Jetpack Compose
 - Android Architecture Component
 
 ### DI
+
 - Dagger Hilt
 
 ### API
+
 - Retrofit2
 - OkHttp3
 - Gson

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,7 +21,10 @@ android {
             useSupportLibrary true
         }
 
-        buildConfigField "String", "GITHUB_TOKEN", "\"${project.properties['GITHUB_TOKEN']}\""
+        def properties = new Properties()
+        properties.load(project.rootProject.file('local.properties').newDataInputStream())
+        def GITHUB_TOKEN = properties.getProperty("GITHUB_TOKEN")
+        buildConfigField "String", "GITHUB_TOKEN", "\"${GITHUB_TOKEN}\""
     }
 
     buildTypes {

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,5 +21,3 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
-# Custom properties
-GITHUB_TOKEN="\"REPLACE_YOUR_GITHUB_TOKEN\""


### PR DESCRIPTION
# 概要
Git対象のgradle.propertiesだと間違えてGITHUB_TOKENを含めてpushしてしまう恐れがあるため、local.propertiesで管理する