### PR TITLE
ユーザー詳細画面を表示するためのAPI処理を並列実行する

### DIFF
--- a/app/src/main/java/dev/dai/githubclient/data/repository/UserRepository.kt
+++ b/app/src/main/java/dev/dai/githubclient/data/repository/UserRepository.kt
@@ -4,6 +4,8 @@ import dev.dai.githubclient.data.api.GithubApi
 import dev.dai.githubclient.data.mapper.toGithubRepoList
 import dev.dai.githubclient.data.mapper.toUser
 import dev.dai.githubclient.model.UserDetail
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -16,17 +18,20 @@ class DefaultUserRepository @Inject constructor(
   private val githubApi: GithubApi
 ) : UserRepository {
 
-  override suspend fun userDetail(userName: String): UserDetail {
-    val user = githubApi.user(userName).toUser()
-    val githubRepoList =
+  override suspend fun userDetail(userName: String): UserDetail = coroutineScope {
+    val user = async {
+      githubApi.user(userName).toUser()
+    }
+    val githubRepoList = async {
       githubApi.userGithubRepo(
         userName = userName,
         perPage = FETCH_GITHUB_REPO_PER_PAGE,
         sort = FETCH_GITHUB_REPO_SORT
       ).toGithubRepoList()
-    return UserDetail(
-      user = user,
-      githubRepoList = githubRepoList
+    }
+    UserDetail(
+      user = user.await(),
+      githubRepoList = githubRepoList.await()
     )
   }
 

--- a/app/src/test/java/dev/dai/githubclient/data/repository/UserRepositoryTest.kt
+++ b/app/src/test/java/dev/dai/githubclient/data/repository/UserRepositoryTest.kt
@@ -26,7 +26,7 @@ class UserRepositoryTest : DescribeSpec({
   describe("#userDetail") {
     val userName = "user"
     val sort = "pushed"
-    context("response success") {
+    context("request success") {
       coEvery {
         githubApi.user(userName)
       } returns UserBody(
@@ -83,9 +83,49 @@ class UserRepositoryTest : DescribeSpec({
       }
     }
 
-    context("response fail") {
+    context("request user failed") {
       coEvery {
         githubApi.user(userName)
+      } throws Exception()
+
+      coEvery {
+        githubApi.userGithubRepo(userName, 50, sort)
+      } returns listOf(
+        GithubRepoBody(
+          id = 0,
+          name = "ComposeGithubClient",
+          description = "Github Client for Android Jetpack Compose",
+          fork = false,
+          htmlUrl = "https://github.com/Dai1678/ComposeGithubClient",
+          language = "Kotlin",
+          stargazersCount = 0
+        )
+      )
+
+      it("throw Exception") {
+        shouldThrow<Exception> { repository.userDetail(userName) }
+      }
+
+      it("verify") {
+        coVerify(exactly = 0) { githubApi.user(userName) }
+        coVerify(exactly = 0) { githubApi.userGithubRepo(userName, 50, sort) }
+      }
+    }
+
+    context("request userGithubRepo failed") {
+      coEvery {
+        githubApi.user(userName)
+      } returns UserBody(
+        id = 0,
+        userName = userName,
+        fullName = "user user",
+        avatarUrl = "https://placehold.jp/240x240.png",
+        following = 0,
+        followers = 0
+      )
+
+      coEvery {
+        githubApi.userGithubRepo(userName, 50, sort)
       } throws Exception()
 
       it("throw Exception") {


### PR DESCRIPTION
# 背景
タイトルの通り

# やったこと
- async awaitで並列処理するように修正
- テストコード追加